### PR TITLE
Issue #182 when scaling the cluster out, check joining nodes before finishing action

### DIFF
--- a/controllers/cassandracluster/cassandra_status.go
+++ b/controllers/cassandracluster/cassandra_status.go
@@ -474,7 +474,7 @@ func (rcc *CassandraClusterReconciler) UpdateCassandraRackStatusPhase(ctx contex
 			return
 		}
 		//If yes, just check that lastPod is running
-		podsList, err := rcc.ListPods(ctx, cc.Namespace, k8s.LabelsForCassandraDCRack(cc, dcName, rackName))
+		podsList, err := rcc.ListPodsOrderByNameAscending(ctx, cc.Namespace, k8s.LabelsForCassandraDCRack(cc, dcName, rackName))
 		if err != nil || len(podsList.Items) < 1 {
 			return
 		}

--- a/controllers/cassandracluster/cassandra_status.go
+++ b/controllers/cassandracluster/cassandra_status.go
@@ -167,7 +167,7 @@ func needToWaitDelayBeforeCheck(cc *api.CassandraCluster, dcRackName string, sto
 		t := *lastAction.StartTime
 		now := metav1.Now()
 
-		if t.Add(api.DefaultDelayWait * time.Second).After(now.Time) {
+		if t.Add(delayWait()).After(now.Time) {
 			logrus.WithFields(logrus.Fields{"cluster": cc.Name,
 				"rack": dcRackName}).Info(
 				fmt.Sprintf("The Operator Waits %s seconds for the action to start correctly",
@@ -177,6 +177,13 @@ func needToWaitDelayBeforeCheck(cc *api.CassandraCluster, dcRackName string, sto
 		}
 	}
 	return false
+}
+
+// visible for tests
+var delayWait = defaultDelayWait
+
+func defaultDelayWait() time.Duration {
+	return api.DefaultDelayWait * time.Second
 }
 
 // UpdateStatusIfconfigMapHasChanged updates CassandraCluster Action Status if it detect a changes :

--- a/controllers/cassandracluster/cassandra_status.go
+++ b/controllers/cassandracluster/cassandra_status.go
@@ -372,14 +372,28 @@ func (rcc *CassandraClusterReconciler) UpdateStatusIfActionEnded(ctx context.Con
 			//Does the Scaling ended ?
 			if nodesPerRacks == storedStatefulSet.Status.Replicas {
 
-				podsList, err := rcc.ListPods(ctx, cc.Namespace, k8s.LabelsForCassandraDCRack(cc, dcName, rackName))
+				podsList, err := rcc.ListPodsOrderByNameAscending(ctx, cc.Namespace, k8s.LabelsForCassandraDCRack(cc, dcName, rackName))
 				nb := len(podsList.Items)
 				if err != nil || nb < 1 {
 					return false
 				}
+				if nb < int(nodesPerRacks) {
+					logrus.WithFields(logrus.Fields{"cluster": cc.Name, "rack": dcRackName}).Warn(fmt.Sprintf(
+						"Although statefulSet has %d replicas, only %d matching pods found", nodesPerRacks, nb))
+					return false
+				}
 				pod := podsList.Items[nodesPerRacks-1]
+
 				//We need lastPod to be running to consider ScaleUp ended
 				if cassandraPodIsReady(&pod) {
+					if hasJoiningNodes, err := rcc.hasJoiningNodes(ctx, cc); err != nil {
+						return false
+					} else if hasJoiningNodes {
+						logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc": dcName, "rack": rackName,
+							"err": err}).Info("Cluster has joining nodes, ScaleUp not yet completed")
+						return false
+					}
+
 					logrus.WithFields(logrus.Fields{"cluster": cc.Name, "rack": dcRackName}).Info("ScaleUp is Done")
 					rackLastAction.Status = api.StatusDone
 					rackLastAction.EndTime = &now

--- a/controllers/cassandracluster/cassandra_status_test.go
+++ b/controllers/cassandracluster/cassandra_status_test.go
@@ -17,8 +17,10 @@ package cassandracluster
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cscetbon/casskop/controllers/common"
+	"github.com/jarcoal/httpmock"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -264,6 +266,9 @@ func helperCreateCassandraCluster(ctx context.Context, t *testing.T, cassandraCl
 }
 
 func TestCassandraClusterReconciler(t *testing.T) {
+	// tests speed-up
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
 
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
@@ -284,6 +289,10 @@ func TestCassandraClusterReconciler(t *testing.T) {
 
 // test that we detect an addition of a configmap
 func TestUpdateStatusIfconfigMapHasChangedWithNoConfigMap(t *testing.T) {
+	// tests speed-up
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
 	rcc, req := helperCreateCassandraCluster(context.TODO(), t, "cassandracluster-2DC.yaml")
@@ -337,6 +346,10 @@ func TestUpdateStatusIfconfigMapHasChangedWithNoConfigMap(t *testing.T) {
 
 // test that we detect a change in a configmap
 func TestUpdateStatusIfconfigMapHasChangedWithConfigMap(t *testing.T) {
+	// tests speed-up
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
 	rcc, req := helperCreateCassandraCluster(context.TODO(), t, "cassandracluster-2DC-configmap.yaml")
@@ -408,6 +421,10 @@ func TestUpdateStatusIfconfigMapHasChangedWithConfigMap(t *testing.T) {
 
 // test that we detect a change in a the docker image
 func TestUpdateStatusIfDockerImageHasChanged(t *testing.T) {
+	// tests speed-up
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
 	rcc, req := helperCreateCassandraCluster(context.TODO(), t, "cassandracluster-2DC-configmap.yaml")
@@ -457,4 +474,18 @@ func TestUpdateStatusIfDockerImageHasChanged(t *testing.T) {
 		}
 	}
 
+}
+
+func overrideDelayWaitWithNoDelay() {
+	delayWait = func() time.Duration {
+		return 0
+	}
+	retryInterval = func() time.Duration {
+		return time.Millisecond
+	}
+}
+
+func restoreDefaultDelayWait() {
+	delayWait = defaultDelayWait
+	retryInterval = defaultRetryInterval
 }

--- a/controllers/cassandracluster/cassandra_status_test.go
+++ b/controllers/cassandracluster/cassandra_status_test.go
@@ -97,6 +97,8 @@ func HelperInitCluster(t *testing.T, name string) (*CassandraClusterReconciler,
 	var cc api.CassandraCluster
 	yaml.Unmarshal(common.HelperLoadBytes(t, name), &cc)
 
+	cc.UID = "123456789" //We need to set a UID so PatchMaker does not fail when comparing owner references
+
 	ccList := api.CassandraClusterList{}
 	//Create Fake client
 	//Objects to track in the Fake client
@@ -203,33 +205,11 @@ func helperCreateCassandraCluster(ctx context.Context, t *testing.T, cassandraCl
 			rcc.Client.Status().Update(ctx, sts)
 
 			//Create Statefulsets associated fake Pods
-			podTemplate := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "template",
-					Namespace: namespace,
-					Labels: map[string]string{
-						"cluster":                              cc.Labels["cluster"],
-						"dc-rack":                              dcRackName,
-						"cassandraclusters.db.orange.com.dc":   dc.Name,
-						"cassandraclusters.db.orange.com.rack": rack.Name,
-						"app":                                  "cassandracluster",
-						"cassandracluster":                     cc.Name,
-					},
-				},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
-					ContainerStatuses: []v1.ContainerStatus{
-						{
-							Name:  "cassandra",
-							Ready: true,
-						},
-					},
-				},
-			}
+			podTemplate := fakePodTemplate(cc, dc.Name, rack.Name)
 
 			for i := 0; i < int(sts.Status.Replicas); i++ {
 				pod := podTemplate.DeepCopy()
-				pod.Name = sts.Name + strconv.Itoa(i)
+				pod.Name = sts.Name + "-" + strconv.Itoa(i)
 				pod.Spec.Hostname = pod.Name
 				pod.Spec.Subdomain = cc.Name
 				if err = rcc.CreatePod(ctx, pod); err != nil {
@@ -263,6 +243,33 @@ func helperCreateCassandraCluster(ctx context.Context, t *testing.T, cassandraCl
 	assert.Equal(api.StatusDone, cc.Status.LastClusterActionStatus)
 
 	return rcc, &req
+}
+
+func fakePodTemplate(cc *api.CassandraCluster, dcName, rackName string) v1.Pod {
+	dcRackName := cc.GetDCRackName(dcName, rackName)
+	return v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"cluster":                              cc.Labels["cluster"],
+				"dc-rack":                              dcRackName,
+				"cassandraclusters.db.orange.com.dc":   dcName,
+				"cassandraclusters.db.orange.com.rack": rackName,
+				"app":                                  "cassandracluster",
+				"cassandracluster":                     cc.Name,
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "cassandra",
+					Ready: true,
+				},
+			},
+		},
+	}
 }
 
 func TestCassandraClusterReconciler(t *testing.T) {
@@ -474,6 +481,24 @@ func TestUpdateStatusIfDockerImageHasChanged(t *testing.T) {
 		}
 	}
 
+}
+
+func assertRackStatusPhase(assert *assert.Assertions, rcc *CassandraClusterReconciler, dcRackName string, expectedPhase api.ClusterStateInfo) {
+	assert.Equal(expectedPhase.Name, rcc.cc.Status.CassandraRackStatus[dcRackName].Phase, dcRackName+" phase")
+}
+
+func assertClusterStatusPhase(assert *assert.Assertions, rcc *CassandraClusterReconciler, expectedPhase api.ClusterStateInfo) {
+	assert.Equal(expectedPhase.Name, rcc.cc.Status.Phase, "cluster phase")
+}
+
+func assertRackStatusLastAction(assert *assert.Assertions, rcc *CassandraClusterReconciler, dcRackName string, expectedActionType api.ClusterStateInfo, expectedActionStatus string) {
+	assert.Equal(expectedActionType.Name, rcc.cc.Status.CassandraRackStatus[dcRackName].CassandraLastAction.Name, "dc1-rack1 last action type")
+	assert.Equal(expectedActionStatus, rcc.cc.Status.CassandraRackStatus[dcRackName].CassandraLastAction.Status, "dc1-rack1 last action status")
+}
+
+func assertClusterStatusLastAction(assert *assert.Assertions, rcc *CassandraClusterReconciler, expectedActionType api.ClusterStateInfo, expectedActionStatus string) {
+	assert.Equal(expectedActionType.Name, rcc.cc.Status.LastClusterAction, "cluster last action type")
+	assert.Equal(expectedActionStatus, rcc.cc.Status.LastClusterActionStatus, "cluster last action status")
 }
 
 func overrideDelayWaitWithNoDelay() {

--- a/controllers/cassandracluster/decommission_test.go
+++ b/controllers/cassandracluster/decommission_test.go
@@ -69,7 +69,7 @@ type podName struct {
 }
 
 func podHost(stfsName string, id int8, rcc *CassandraClusterReconciler) podName {
-	name := stfsName + strconv.Itoa(int(id))
+	name := stfsName + "-" + strconv.Itoa(int(id))
 	return podName{name, name + "." + rcc.cc.Name}
 }
 

--- a/controllers/cassandracluster/decommission_test.go
+++ b/controllers/cassandracluster/decommission_test.go
@@ -81,12 +81,15 @@ func deletePodNotDeletedByFakeClient(rcc *CassandraClusterReconciler, host podNa
 }
 
 func TestOneDecommission(t *testing.T) {
-	ctx := context.TODO()
-	rcc, req := createCassandraClusterWithNoDisruption(t, "cassandracluster-1DC.yaml")
+	overrideDelayWaitWithNoDelay()
+	defer restoreDefaultDelayWait()
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	assert := assert.New(t)
+
+	ctx := context.TODO()
+	rcc, req := createCassandraClusterWithNoDisruption(t, "cassandracluster-1DC.yaml")
 
 	assert.Equal(int32(3), rcc.cc.Spec.NodesPerRacks)
 

--- a/controllers/cassandracluster/pod.go
+++ b/controllers/cassandracluster/pod.go
@@ -88,12 +88,7 @@ func GetLastOrFirstPodItem(podsList []v1.Pod, last bool) (*v1.Pod, error) {
 
 	items := podsList[:]
 
-	// Sort pod list using ending number in field ObjectMeta.Name
-	sort.Slice(items, func(i, j int) bool {
-		id1, _ := strconv.Atoi(reEndingNumber.FindString(items[i].ObjectMeta.Name))
-		id2, _ := strconv.Atoi(reEndingNumber.FindString(items[j].ObjectMeta.Name))
-		return id1 < id2
-	})
+	sortPodsList(items)
 
 	idx := 0
 	if last {
@@ -103,6 +98,15 @@ func GetLastOrFirstPodItem(podsList []v1.Pod, last bool) (*v1.Pod, error) {
 	pod := podsList[idx]
 
 	return &pod, nil
+}
+
+// sortPodsList sorts pod list using ending number in field ObjectMeta.Name
+func sortPodsList(items []v1.Pod) {
+	sort.Slice(items, func(i, j int) bool {
+		id1, _ := strconv.Atoi(reEndingNumber.FindString(items[i].ObjectMeta.Name))
+		id2, _ := strconv.Atoi(reEndingNumber.FindString(items[j].ObjectMeta.Name))
+		return id1 < id2
+	})
 }
 
 // GetFirstPod returns the first pod satisfying the selector and being in the namespace
@@ -182,7 +186,6 @@ func (rcc *CassandraClusterReconciler) hasUnschedulablePod(ctx context.Context, 
 }
 
 func (rcc *CassandraClusterReconciler) ListPods(ctx context.Context, namespace string, selector map[string]string) (*v1.PodList, error) {
-
 	clientOpt := &client.ListOptions{
 		Namespace:     namespace,
 		LabelSelector: labels.SelectorFromSet(selector),
@@ -194,6 +197,14 @@ func (rcc *CassandraClusterReconciler) ListPods(ctx context.Context, namespace s
 
 	pl := &v1.PodList{}
 	return pl, rcc.Client.List(ctx, pl, opt...)
+}
+
+func (rcc *CassandraClusterReconciler) ListPodsOrderByNameAscending(ctx context.Context, namespace string, selector map[string]string) (*v1.PodList, error) {
+	pods, err := rcc.ListPods(ctx, namespace, selector)
+	if pods != nil {
+		sortPodsList(pods.Items)
+	}
+	return pods, err
 }
 
 func (rcc *CassandraClusterReconciler) CreatePod(ctx context.Context, pod *v1.Pod) error {

--- a/controllers/cassandracluster/pod_operation.go
+++ b/controllers/cassandracluster/pod_operation.go
@@ -112,21 +112,9 @@ func (rcc *CassandraClusterReconciler) handlePodOperation(ctx context.Context, c
 		return breakResyncLoopSwitch, err
 	}
 
-	podsList, err := rcc.ListCassandraClusterPods(ctx, cc)
+	hasJoiningNodes, err := rcc.hasJoiningNodes(ctx, cc)
 	if err != nil {
-		return true, err
-	}
-	firstPod, err := GetLastOrFirstPodReady(podsList, false)
-	if err != nil {
-		return true, err
-	}
-
-	hostName := k8s.PodHostname(*firstPod)
-	jolokiaClient, _ := NewJolokiaClient(ctx, hostName, JolokiaPort, rcc, cc.Spec.ImageJolokiaSecret, cc.Namespace)
-
-	hasJoiningNodes, err := jolokiaClient.hasJoiningNodes()
-	if err != nil {
-		return true, err
+		return breakResyncLoop, err
 	}
 	if hasJoiningNodes {
 		logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc": dcName, "rack": rackName,
@@ -149,6 +137,24 @@ func (rcc *CassandraClusterReconciler) handlePodOperation(ctx context.Context, c
 	}
 
 	return breakResyncLoopSwitch, err
+}
+
+func (rcc *CassandraClusterReconciler) hasJoiningNodes(ctx context.Context, cc *api.CassandraCluster) (bool, error) {
+	podsList, err := rcc.ListCassandraClusterPods(ctx, cc)
+	if err != nil {
+		return false, err
+	}
+	firstPod, err := GetLastOrFirstPodReady(podsList, false)
+	if err != nil {
+		return false, err
+	}
+
+	hostName := k8s.PodHostname(*firstPod)
+	jolokiaClient, err := NewJolokiaClient(ctx, hostName, JolokiaPort, rcc, cc.Spec.ImageJolokiaSecret, cc.Namespace)
+	if err != nil {
+		return false, err
+	}
+	return jolokiaClient.hasJoiningNodes()
 }
 
 // addPodOperationLabels will add Pod Labels labels on all Pod in the Current dcRackName

--- a/controllers/cassandracluster/pod_operation.go
+++ b/controllers/cassandracluster/pod_operation.go
@@ -675,7 +675,7 @@ func (rcc *CassandraClusterReconciler) finalizeOperation(ctx context.Context, er
 		}
 		logrus.WithFields(logrus.Fields{"cluster": cc.Name, "rack": dcRackName, "pod": pod.Name,
 			"status": status}).Debug("Can't get new version of Cassandra Cluster. Will try again")
-		time.Sleep(retryInterval)
+		time.Sleep(retryInterval())
 	}
 }
 
@@ -830,7 +830,7 @@ func (rcc *CassandraClusterReconciler) runRemove(ctx context.Context, hostName s
 }
 
 func (rcc *CassandraClusterReconciler) waitUntilPvcIsDeleted(ctx context.Context, namespace, pvcName string) error {
-	err := wait.Poll(retryInterval, deletedPvcTimeout, func() (done bool, err error) {
+	err := wait.Poll(retryInterval(), deletedPvcTimeout, func() (done bool, err error) {
 		_, err = rcc.GetPVC(ctx, namespace, pvcName)
 		if err != nil && apierrors.IsNotFound(err) {
 			logrus.WithFields(logrus.Fields{"namespace": namespace,

--- a/controllers/cassandracluster/scaleup_test.go
+++ b/controllers/cassandracluster/scaleup_test.go
@@ -3,9 +3,11 @@ package cassandracluster
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
+	api "github.com/cscetbon/casskop/api/v2"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,6 +33,31 @@ func registerJolokiaOperationJoiningNodes(host podName, numberOfJoiningNodes int
 										"value": %s,
 										"timestamp": 1528850319,
 										"status": 200}`, stringOfSlice(joiningNodes))))
+}
+
+func simulateNewPodsReady(t *testing.T, rcc *CassandraClusterReconciler, stfsName string, dc api.DC, scaleFrom, scaleTo int) {
+	assert := assert.New(t)
+
+	sts, err := rcc.GetStatefulSet(ctx, rcc.cc.Namespace, stfsName)
+	assert.NoError(err, "get sts")
+
+	//Now simulate sts to be ready for CassKop
+	sts.Status.Replicas = *sts.Spec.Replicas
+	sts.Status.ReadyReplicas = *sts.Spec.Replicas
+	err = rcc.Client.Status().Update(ctx, sts)
+	assert.NoError(err, "update sts status")
+
+	// create new fake Pods (consequence of scale-out) so action may finish
+	podTemplate := fakePodTemplate(rcc.cc, dc.Name, dc.Rack[0].Name)
+	for i := scaleFrom; i < scaleTo; i++ {
+		pod := podTemplate.DeepCopy()
+		pod.Name = sts.Name + "-" + strconv.Itoa(i)
+		pod.Spec.Hostname = pod.Name
+		pod.Spec.Subdomain = rcc.cc.Name
+		if err = rcc.CreatePod(ctx, pod); err != nil {
+			t.Fatalf("can't create pod: (%v)", err)
+		}
+	}
 }
 
 func TestAddTwoNodes(t *testing.T) {
@@ -78,4 +105,30 @@ func TestAddTwoNodes(t *testing.T) {
 		assert.GreaterOrEqual(jolokiaCallsCount(firstPod), 1)
 		assertStatefulsetReplicas(ctx, t, rcc, expectedReplicas+1, cassandraCluster.Namespace, stfsName)
 	}
+
+	assertClusterStatusPhase(assert, rcc, api.ClusterPhasePending)
+	assertRackStatusPhase(assert, rcc, "dc1-rack1", api.ClusterPhasePending)
+	assertClusterStatusLastAction(assert, rcc, api.ActionScaleUp, api.StatusOngoing)
+	assertRackStatusLastAction(assert, rcc, "dc1-rack1", api.ActionScaleUp, api.StatusOngoing)
+
+	//Reconcile does not end the action even when sts and all new pods are ready, because there are joining nodes
+	simulateNewPodsReady(t, rcc, stfsName, dc, 3, 5)
+	registerJolokiaOperationJoiningNodes(firstPod, 1)
+	for reconcileIteration := 0; reconcileIteration <= 2; reconcileIteration++ {
+		reconcileValidation(t, rcc, *req)
+		assert.GreaterOrEqual(jolokiaCallsCount(firstPod), 1)
+		assertClusterStatusPhase(assert, rcc, api.ClusterPhasePending)
+		assertRackStatusPhase(assert, rcc, "dc1-rack1", api.ClusterPhaseRunning)
+		assertClusterStatusLastAction(assert, rcc, api.ActionScaleUp, api.StatusOngoing)
+		assertRackStatusLastAction(assert, rcc, "dc1-rack1", api.ActionScaleUp, api.StatusOngoing)
+	}
+
+	//Reconcile ends the action when sts and all new pods are ready and there are no joining nodes
+	registerJolokiaOperationJoiningNodes(firstPod, 0)
+	reconcileValidation(t, rcc, *req)
+	assert.GreaterOrEqual(jolokiaCallsCount(firstPod), 1)
+	assertClusterStatusPhase(assert, rcc, api.ClusterPhaseRunning)
+	assertRackStatusPhase(assert, rcc, "dc1-rack1", api.ClusterPhaseRunning)
+	assertClusterStatusLastAction(assert, rcc, api.ActionScaleUp, api.StatusDone)
+	assertRackStatusLastAction(assert, rcc, "dc1-rack1", api.ActionScaleUp, api.StatusDone)
 }

--- a/controllers/cassandracluster/scaleup_test.go
+++ b/controllers/cassandracluster/scaleup_test.go
@@ -34,11 +34,14 @@ func registerJolokiaOperationJoiningNodes(host podName, numberOfJoiningNodes int
 }
 
 func TestAddTwoNodes(t *testing.T) {
-	rcc, req := createCassandraClusterWithNoDisruption(t, "cassandracluster-1DC.yaml")
+	overrideDelayWaitWithNoDelay()
+	defer restoreDefaultDelayWait()
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	assert := assert.New(t)
+
+	rcc, req := createCassandraClusterWithNoDisruption(t, "cassandracluster-1DC.yaml")
 
 	assert.Equal(int32(3), rcc.cc.Spec.NodesPerRacks)
 

--- a/controllers/cassandracluster/statefulset.go
+++ b/controllers/cassandracluster/statefulset.go
@@ -39,9 +39,15 @@ import (
 )
 
 var (
-	retryInterval = time.Second
-	timeout       = time.Second * 5
+	// visible for tests
+	retryInterval = defaultRetryInterval
+
+	timeout = time.Second * 5
 )
+
+func defaultRetryInterval() time.Duration {
+	return time.Second
+}
 
 // GetStatefulSet return the Statefulset name from the cluster in the namespace
 func (rcc *CassandraClusterReconciler) GetStatefulSet(ctx context.Context, namespace, name string) (*appsv1.StatefulSet, error) {
@@ -89,7 +95,7 @@ func (rcc *CassandraClusterReconciler) UpdateStatefulSet(ctx context.Context, st
 		return fmt.Errorf("failed to update cassandra statefulset: %cc", err)
 	}
 	//Check that the new revision of statefulset has been taken into account
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	err := wait.Poll(retryInterval(), timeout, func() (done bool, err error) {
 		newSts, err := rcc.GetStatefulSet(ctx, statefulSet.Namespace, statefulSet.Name)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed to get cassandra statefulset: %cc", err)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #182
| License         | Apache 2.0


### What's in this PR?
When scaling the cluster out, added check for joining nodes before finishing action (`ScaleOut=Done`)


### Why?
To avoid setting cluster `Phase=Running` precociously.
Details in issue #182


### Checklist
- [x] Implementation tested
